### PR TITLE
Remove check for two URL params

### DIFF
--- a/src/pages/tab/[...id].tsx
+++ b/src/pages/tab/[...id].tsx
@@ -394,12 +394,6 @@ export async function getStaticPaths() {
 }
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
-  if (params?.id?.length !== 2) {
-    return {
-      notFound: true,
-    };
-  }
-
   let props: TabDto = {
     ...defaultProps,
   };


### PR DESCRIPTION
This breaks tabs with non-ascii titles or musicians, because UG generates URLs for these tabs that only have the id.

Solves: #37 